### PR TITLE
Add Colab speech-to-speech pipeline and index-tts2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 文字翻译支持 `微软翻译|Google翻译|百度翻译|腾讯翻译|ChatGPT|AzureAI|Gemini|DeepSeek|claude|DeepL|DeepLX|字节火山|离线翻译OTT|自定义API等`
 
-文字合成语音支持 `Edge tts` `Google tts` `Azure AI TTS` `Openai TTS` `Elevenlabs TTS` `自定义TTS服务器api` `GPT-SoVITS` `F5-TTS` `Index-tts` `ChatterBox` `Gemini-tts` [clone-voice](https://github.com/jianchang512/clone-voice)  [ChatTTS-ui](https://github.com/jianchang512/ChatTTS-ui)  [Fish TTS](https://github.com/fishaudio/fish-speech)  [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) 
+文字合成语音支持 `Edge tts` `Google tts` `Azure AI TTS` `Openai TTS` `Elevenlabs TTS` `自定义TTS服务器api` `GPT-SoVITS` `F5-TTS` `Index-tts/Index-tts2` `ChatterBox` `Gemini-tts` [clone-voice](https://github.com/jianchang512/clone-voice)  [ChatTTS-ui](https://github.com/jianchang512/ChatTTS-ui)  [Fish TTS](https://github.com/fishaudio/fish-speech)  [CosyVoice](https://github.com/FunAudioLLM/CosyVoice)
 
 允许保留背景伴奏音乐等(基于uvr5)
 
@@ -52,6 +52,8 @@
 ![pyvideotrans-home](https://github.com/user-attachments/assets/b2f95a7f-b4e5-4a6d-b2a5-eb6cd22531e0)
 
 [![Open In Colab](https://img.shields.io/badge/Colab-F9AB00?style=for-the-badge&logo=googlecolab&color=525252)](https://colab.research.google.com/drive/1kPTeAMz3LnWRnGmabcz4AWW42hiehmfm?usp=sharing)
+
+- [Google Colab Speech-to-Speech 指南](docs/google_colab_s2s.md)
 
 ## 预打包版本(仅win10/win11可用，MacOS/Linux系统使用源码部署)
 

--- a/colab_s2s.py
+++ b/colab_s2s.py
@@ -1,0 +1,288 @@
+"""Utilities for running speech-to-speech translation inside Google Colab.
+
+This helper keeps the orchestration logic in one place so that notebooks can
+focus on user interaction.  It wires together recognition, translation and
+index-tts2 cloning in a sequential pipeline that mirrors the desktop
+application.
+"""
+from __future__ import annotations
+
+import contextlib
+import time
+from pathlib import Path
+from queue import Empty
+from typing import Dict, List, Optional, Tuple, Union
+
+from videotrans.configure import config
+from videotrans.task.trans_create import TransCreate
+from videotrans.util import tools
+from videotrans import recognition, translator, tts
+
+
+_TRANSLATE_NAME_TO_INDEX: Dict[str, int] = {
+    'google': translator.GOOGLE_INDEX,
+    'microsoft': translator.MICROSOFT_INDEX,
+    'deepl': translator.DEEPL_INDEX,
+    'deeplx': translator.DEEPLX_INDEX,
+    'baidu': translator.BAIDU_INDEX,
+    'tencent': translator.TENCENT_INDEX,
+    'ali': translator.ALI_INDEX,
+}
+
+_RECOGN_NAME_TO_INDEX: Dict[str, int] = {
+    'faster-whisper': recognition.FASTER_WHISPER,
+    'openai-whisper': recognition.OPENAI_WHISPER,
+    'funasr': recognition.FUNASR_CN,
+    'google': recognition.GOOGLE_SPEECH,
+    'gemini': recognition.GEMINI_SPEECH,
+}
+
+
+def _language_label(code: str) -> Tuple[str, str]:
+    """Return language label and normalized code for pyvideotrans configs."""
+    if not code:
+        raise ValueError("language code must not be empty")
+    normalized = code.lower().replace('_', '-')
+    label = config.langlist.get(normalized)
+    if not label and normalized in config.rev_langlist:
+        label = config.langlist[config.rev_langlist[normalized]]
+    if not label:
+        label = config.langlist.get(normalized.split('-')[0])
+    if not label:
+        raise ValueError(f"Unsupported language code: {code}")
+    return label, normalized
+
+
+def _resolve_translate_backend(value: Union[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+    key = value.lower()
+    if key not in _TRANSLATE_NAME_TO_INDEX:
+        raise ValueError(
+            f"Unknown translate backend '{value}'. Allowed keys: {sorted(_TRANSLATE_NAME_TO_INDEX)}"
+        )
+    return _TRANSLATE_NAME_TO_INDEX[key]
+
+
+def _resolve_recogn_backend(value: Union[str, int]) -> int:
+    if isinstance(value, int):
+        return value
+    key = value.lower()
+    if key not in _RECOGN_NAME_TO_INDEX:
+        raise ValueError(
+            f"Unknown recognition backend '{value}'. Allowed keys: {sorted(_RECOGN_NAME_TO_INDEX)}"
+        )
+    return _RECOGN_NAME_TO_INDEX[key]
+
+
+def _consume_logs(uuid: str) -> List[Dict[str, str]]:
+    queue = config.uuid_logs_queue.get(uuid)
+    if queue is None:
+        return []
+    messages: List[Dict[str, str]] = []
+    with contextlib.suppress(Exception):
+        while True:
+            try:
+                item = queue.get_nowait()
+            except Empty:
+                break
+            else:
+                if isinstance(item, dict):
+                    messages.append(item)
+    return messages
+
+
+def _prepare_environment(output_root: Path) -> None:
+    output_root.mkdir(parents=True, exist_ok=True)
+    Path(config.TEMP_DIR).mkdir(parents=True, exist_ok=True)
+    config.exec_mode = 'colab'
+    config.exit_soft = False
+    config.current_status = 'ing'
+    config.box_recogn = 'ing'
+    config.box_trans = 'ing'
+    config.box_tts = 'ing'
+    config.global_msg.clear()
+
+
+def _restore_environment(previous_status: Dict[str, str]) -> None:
+    config.current_status = previous_status.get('current_status', 'stop')
+    config.box_recogn = previous_status.get('box_recogn', 'stop')
+    config.box_trans = previous_status.get('box_trans', 'stop')
+    config.box_tts = previous_status.get('box_tts', 'stop')
+
+
+def run_speech_to_speech(
+    *,
+    input_path: Union[str, Path],
+    target_language: str,
+    index_tts_url: str,
+    whisper_model: str = 'large-v2',
+    translate_backend: Union[str, int] = 'google',
+    recognition_backend: Union[str, int] = 'faster-whisper',
+    output_root: Union[str, Path] = '/content/pyvideotrans-output',
+    separate_vocals: bool = True,
+    denoise: bool = False,
+    split_type: str = 'all',
+    voice_role: str = 'clone',
+    voice_rate: str = '+0%',
+    volume: str = '+0%',
+    pitch: str = '+0Hz',
+    voice_autorate: bool = True,
+    video_autorate: bool = True,
+    use_cuda: bool = True,
+    collect_logs: bool = True,
+) -> Dict[str, Union[str, Dict[str, str], List[Dict[str, str]]]]:
+    """Execute the full speech-to-speech translation pipeline.
+
+    Parameters
+    ----------
+    input_path:
+        Source video or audio file on the Colab filesystem.
+    target_language:
+        ISO language code such as ``en`` or ``ja``.
+    index_tts_url:
+        Base URL of the index-tts2 webui (e.g. ``http://127.0.0.1:7860``).
+    whisper_model:
+        Name of the Faster-Whisper model to use.
+    translate_backend:
+        Either an integer index or one of ``google``, ``microsoft``, ``deepl``
+        ``deeplx``, ``baidu``, ``tencent`` or ``ali``.
+    recognition_backend:
+        Either an integer index or one of ``faster-whisper`` (default),
+        ``openai-whisper``, ``funasr``, ``google`` or ``gemini``.
+    output_root:
+        Directory where result folders will be created.
+    separate_vocals:
+        If True, perform vocal/music separation before cloning.
+    denoise:
+        Apply noise removal to the recognition audio.
+    split_type:
+        ``all`` for full utterances or ``avg`` for even splitting.
+    voice_role:
+        TTS role. Use ``clone`` to keep the original timbre.
+    voice_rate / volume / pitch:
+        TTS prosody adjustments following pyvideotrans formatting.
+    voice_autorate / video_autorate:
+        Enable automatic alignment to better fit subtitles.
+    use_cuda:
+        Whether to run Faster-Whisper on CUDA when available.
+    collect_logs:
+        When True, attach the streaming logs to the return payload.
+    """
+
+    input_path = Path(input_path).expanduser().resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+    if not index_tts_url:
+        raise ValueError('index_tts_url must be provided')
+
+    target_label, target_code = _language_label(target_language)
+    _, source_code = ('Auto', 'auto')
+
+    translate_index = _resolve_translate_backend(translate_backend)
+    recogn_index = _resolve_recogn_backend(recognition_backend)
+
+    output_root = Path(output_root).expanduser().resolve()
+    prev_status = {
+        'current_status': config.current_status,
+        'box_recogn': config.box_recogn,
+        'box_trans': config.box_trans,
+        'box_tts': config.box_tts,
+    }
+    prev_params = {
+        'f5tts_url': config.params.get('f5tts_url'),
+        'f5tts_ttstype': config.params.get('f5tts_ttstype'),
+        'f5tts_is_whisper': config.params.get('f5tts_is_whisper'),
+    }
+
+    start_time = time.time()
+    _prepare_environment(output_root)
+
+    config.params['f5tts_url'] = index_tts_url.strip().rstrip('/')
+    config.params['f5tts_ttstype'] = 'Index-TTS2'
+    config.params['f5tts_is_whisper'] = False
+
+    obj = tools.format_video(input_path.as_posix(), target_dir=output_root.as_posix())
+
+    cfg = {
+        'target_dir': obj['target_dir'],
+        'app_mode': 'biaozhun',
+        'recogn_type': recogn_index,
+        'model_name': whisper_model,
+        'split_type': split_type,
+        'remove_noise': denoise,
+        'is_separate': separate_vocals,
+        'translate_type': translate_index,
+        'target_language': target_label,
+        'target_language_code': target_code,
+        'source_language': source_code,
+        'source_language_code': source_code,
+        'voice_role': voice_role,
+        'voice_rate': voice_rate,
+        'volume': volume,
+        'pitch': pitch,
+        'voice_autorate': voice_autorate,
+        'video_autorate': video_autorate,
+        'tts_type': tts.F5_TTS,
+        'subtitle_type': 0,
+        'cuda': bool(use_cuda),
+    }
+    cfg.update(obj)
+
+    task = TransCreate(cfg=cfg)
+    logs: List[Dict[str, str]] = []
+
+    try:
+        task.prepare()
+        if collect_logs:
+            logs.extend(_consume_logs(task.uuid))
+
+        task.recogn()
+        if collect_logs:
+            logs.extend(_consume_logs(task.uuid))
+
+        if task.shoud_trans:
+            task.trans()
+            if collect_logs:
+                logs.extend(_consume_logs(task.uuid))
+
+        if task.shoud_dubbing:
+            task.dubbing()
+            if collect_logs:
+                logs.extend(_consume_logs(task.uuid))
+
+        task.align()
+        if collect_logs:
+            logs.extend(_consume_logs(task.uuid))
+
+        task.assembling()
+        if collect_logs:
+            logs.extend(_consume_logs(task.uuid))
+
+        task.task_done()
+        if collect_logs:
+            logs.extend(_consume_logs(task.uuid))
+    finally:
+        config.params['f5tts_url'] = prev_params.get('f5tts_url', '')
+        config.params['f5tts_ttstype'] = prev_params.get('f5tts_ttstype', 'F5-TTS')
+        config.params['f5tts_is_whisper'] = prev_params.get('f5tts_is_whisper', False)
+        _restore_environment(prev_status)
+
+    target_dir = Path(task.cfg['target_dir']).resolve()
+    result = {
+        'uuid': task.uuid,
+        'elapsed': time.time() - start_time,
+        'target_dir': target_dir.as_posix(),
+        'translated_video': Path(task.cfg['targetdir_mp4']).resolve().as_posix(),
+        'translated_audio': Path(task.cfg['target_wav_output']).resolve().as_posix() if task.cfg.get('target_wav_output') else '',
+        'target_subtitle': Path(task.cfg['target_sub']).resolve().as_posix() if task.cfg.get('target_sub') else '',
+        'source_subtitle': Path(task.cfg['source_sub']).resolve().as_posix() if task.cfg.get('source_sub') else '',
+    }
+    if collect_logs:
+        result['logs'] = logs
+    return result
+
+
+__all__ = [
+    'run_speech_to_speech',
+]

--- a/docs/google_colab_s2s.md
+++ b/docs/google_colab_s2s.md
@@ -1,0 +1,96 @@
+# 在 Google Colab 上进行语音到语音翻译（Speech-to-Speech）
+
+本文档演示如何在 **Google Colab** 环境中使用 pyVideoTrans 完成完整的视频语音翻译流程，并通过 **index-tts2** 模型保留原音色。
+
+## 一、准备工作
+
+1. 打开 [Google Colab](https://colab.research.google.com/)。
+2. 建议使用 GPU 运行时（`启用 GPU -> 运行时 -> 更改运行时类型 -> 硬件加速器 -> GPU`）。
+3. 准备好视频/音频输入文件，可以上传到 Colab 或 Google Drive。
+4. 确保您已部署并启动 `index-tts2` WebUI，并能够通过公网地址访问（可使用 ngrok/cloudflared 等隧道）。
+
+## 二、快速开始 Notebook
+
+仓库提供了现成的 Notebook：`notebooks/colab_speech_to_speech.ipynb`。
+
+1. 在 Colab 中运行以下命令克隆仓库：
+   ```python
+   !git clone https://github.com/jianchang512/pyvideotrans.git
+   %cd pyvideotrans
+   ```
+2. 打开 `notebooks/colab_speech_to_speech.ipynb` Notebook（Colab 左侧“文件”树中双击即可）。
+3. 按顺序执行 Notebook 各单元：
+   - 克隆/更新仓库并切换目录；
+   - 安装 `requirements-colab.txt` 依赖（包含 CUDA 12.1 下的 Faster-Whisper）；
+   -（可选）挂载 Google Drive 以便读写文件；
+   - 准备示例视频（或者自行上传文件）；
+   - 调用 `run_speech_to_speech` 函数执行完整的语音到语音翻译；
+4. Notebook 中 `result` 字典会返回生成的视频、音频和字幕路径，可直接下载或保存至 Drive。
+
+## 三、`colab_s2s.py` 快速接口说明
+
+新增加的 `colab_s2s.py` 封装了在 Colab 环境下的调用流程，核心函数为：
+
+```python
+from colab_s2s import run_speech_to_speech
+
+result = run_speech_to_speech(
+    input_path='/content/media/sample.mp4',
+    target_language='en',
+    index_tts_url='http://<your-index-tts2-endpoint>',
+    whisper_model='large-v3',
+    translate_backend='google',
+    recognition_backend='faster-whisper',
+    separate_vocals=True,
+    voice_role='clone'
+)
+```
+
+常用参数说明：
+
+| 参数 | 说明 |
+| --- | --- |
+| `input_path` | 输入视频/音频路径（Colab 本地路径或挂载盘路径）。 |
+| `target_language` | 输出语言代码，例如 `en`、`ja`、`zh-cn` 等。 |
+| `index_tts_url` | index-tts2 WebUI 的可访问地址（确保 Colab 可连通）。 |
+| `whisper_model` | Faster-Whisper 模型名称，默认 `large-v2`。 |
+| `translate_backend` | 翻译通道，可选 `google`、`microsoft`、`deepl`、`baidu`、`tencent`、`ali` 等。 |
+| `recognition_backend` | 语音识别通道，可选 `faster-whisper`、`openai-whisper`、`funasr`、`google`、`gemini` 等。 |
+| `separate_vocals` | 是否启用人声/背景音乐分离，默认 `True`。 |
+| `voice_role` | 配音角色，使用 `clone` 可在 index-tts2 中保持原音色。 |
+| `voice_autorate` / `video_autorate` | 是否自动根据字幕对齐音频/视频节奏，默认 `True`。 |
+| `use_cuda` | 是否在 GPU 上运行 Faster-Whisper，默认 `True`。 |
+
+函数返回的 `result` 字典包含：
+
+- `uuid`：本次任务的唯一编号；
+- `elapsed`：执行时长（秒）；
+- `target_dir`：输出目录；
+- `translated_video`：合成后的视频文件路径；
+- `translated_audio`：目标语言音频路径；
+- `target_subtitle`：目标语言字幕路径；
+- `source_subtitle`：原字幕路径；
+- `logs`（可选）：过程日志（如果 `collect_logs=True`）。
+
+## 四、使用 index-tts2 的注意事项
+
+1. WebUI 必须开放 HTTP 接口，并能被 Colab 网络访问。建议使用安全隧道工具（例如 cloudflared、ngrok）。
+2. 参考音频应保持在 10 秒以内、清晰无噪声；在 `voice_role='clone'` 时软件会自动截取原音频片段作为参考。
+3. 若 index-tts2 的接口字段发生变化，`colab_s2s.py` 会自动读取 Gradio API 定义并适配，若仍报缺少参数，可刷新 WebUI 或检查日志。
+
+## 五、常见问题
+
+- **依赖安装较慢**：Colab 首次下载模型与依赖时耗时较久，可挂载 Drive 缓存模型目录。
+- **index-tts2 连接失败**：确认 URL 是否可公开访问，若在本地运行请使用隧道工具映射到公网。
+- **显存不足**：尝试更换较小的 Whisper 模型（如 `medium`/`small`）或关闭 `separate_vocals`。
+- **日志调试**：`result['logs']` 中包含每个阶段的状态信息，便于排查。
+
+## 六、目录结构调整
+
+新增的主要文件：
+
+- `colab_s2s.py`：Colab 专用工具函数集合；
+- `notebooks/colab_speech_to_speech.ipynb`：一步步运行示例；
+- 文档 `docs/google_colab_s2s.md`（即本文）提供操作说明。
+
+通过上述步骤，即可在 Colab 环境完成从语音识别、翻译、到 index-tts2 配音的完整流程，并生成带字幕的视频输出。

--- a/notebooks/colab_speech_to_speech.ipynb
+++ b/notebooks/colab_speech_to_speech.ipynb
@@ -1,0 +1,159 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# pyVideoTrans Speech-to-Speech on Google Colab\n",
+    "\n",
+    "This notebook installs the pyVideoTrans toolkit, prepares runtime dependencies, and\n",
+    "shows how to translate a video into a target language while cloning the original\n",
+    "timbre through **index-tts2**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Clone the repository (run once per session)\n",
+    "If you already have a copy in your Colab environment you can skip this step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys, pathlib\n",
+    "ROOT = pathlib.Path('/content/pyvideotrans')\n",
+    "if not ROOT.exists():\n",
+    "    !git clone https://github.com/jianchang512/pyvideotrans.git {ROOT}\n",
+    "os.chdir(ROOT)\n",
+    "sys.path.insert(0, str(ROOT))\n",
+    "print('Working directory:', os.getcwd())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Install runtime dependencies\n",
+    "This installs the lightweight Colab dependency set (CUDA 12.1 wheels are used\n",
+    "for Faster-Whisper)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U pip\n",
+    "!pip install -r requirements-colab.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. (Optional) Mount Google Drive\n",
+    "Uncomment the cell below if you prefer to read/write media files from Drive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# from google.colab import drive\n",
+    "# drive.mount('/content/drive')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Provide an input clip\\n",
+    "You can upload a file through the Colab UI or download one programmatically.\\n",
+    "The example below downloads a short sample from GitHub."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib, urllib.request, urllib.error\\n",
+    "sample_dir = pathlib.Path('/content/media')\\n",
+    "sample_dir.mkdir(parents=True, exist_ok=True)\\n",
+    "sample_path = sample_dir / 'sample.mp4'\\n",
+    "if not sample_path.exists():\\n",
+    "    url = 'https://github.com/jianchang512/pyvideotrans/releases/download/v0.0/sample.mp4'\\n",
+    "    try:\\n",
+    "        urllib.request.urlretrieve(url, sample_path)\\n",
+    "    except urllib.error.URLError:\\n",
+    "        print('Download failed, please upload your own clip instead.')\\n",
+    "sample_path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Launch speech-to-speech translation\n",
+    "Make sure your `index-tts2` web UI is reachable from Colab (for example via an\n",
+    "ngrok/cloudflared tunnel).  Set the URL below along with your desired target\n",
+    "language."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from colab_s2s import run_speech_to_speech\n",
+    "result = run_speech_to_speech(\n",
+    "    input_path=sample_path,\n",
+    "    target_language='en',\n",
+    "    index_tts_url='http://127.0.0.1:7860',  # replace with your public endpoint\n",
+    "    whisper_model='large-v3',\n",
+    "    translate_backend='google',\n",
+    "    recognition_backend='faster-whisper',\n",
+    "    separate_vocals=True,\n",
+    "    voice_role='clone'\n",
+    ")\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dictionary reports where the translated media and subtitles were saved.\n",
+    "You can download them through the Colab file browser or move them into\n",
+    "Google Drive."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/videotrans/tts/_f5tts.py
+++ b/videotrans/tts/_f5tts.py
@@ -3,7 +3,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional, Tuple
 
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log, \
     RetryError
@@ -24,6 +24,7 @@ class F5TTS(BaseTTS):
 
     def __post_init__(self):
         super().__post_init__()
+        self._index2_endpoint_cache: Optional[Tuple[Optional[str], Optional[int], List[Dict[str, Union[str, Dict]]]]] = None
         self.copydata = copy.deepcopy(self.queue_tts)
         api_url = config.params['f5tts_url'].strip().rstrip('/').lower()
         self.api_url = f'http://{api_url}' if not api_url.startswith('http') else api_url
@@ -208,8 +209,222 @@ class F5TTS(BaseTTS):
         self.has_done += 1
         self._signal(text=f'{config.transobj["kaishipeiyin"]} {self.has_done}/{self.len}')
 
+    def _classify_index2_param(self, param: Dict) -> str:
+        label = (param.get('label') or '').lower()
+        component = (param.get('component') or '').lower()
+        python_type = (param.get('python_type') or '').lower()
+        parameter_name = (param.get('parameter_name') or '').lower()
+
+        text_keywords = {'text', 'script', 'content', 'sentence'}
+        audio_keywords = {'audio', 'voice', 'wav', 'reference', 'prompt'}
+        language_keywords = {'lang', 'language', 'locale'}
+
+        if any(key in component for key in ('audio', 'file', 'upload')):
+            return 'audio'
+        if any(key in label for key in ('emo', 'emotion')):
+            return 'emotion'
+        if any(key in label for key in language_keywords) or any(key in parameter_name for key in language_keywords):
+            return 'language'
+        if any(key in label for key in text_keywords) or any(key in parameter_name for key in text_keywords) \
+                or any(key in python_type for key in ('text', 'str')):
+            if 'ref' in label or 'ref' in parameter_name:
+                return 'ref_text'
+            return 'text'
+        if any(key in label for key in audio_keywords) or any(key in parameter_name for key in audio_keywords) \
+                or 'audio' in python_type:
+            return 'audio'
+        if 'speaker' in label or 'speaker' in parameter_name or 'spk' in label:
+            return 'speaker'
+        if 'silence' in label and 'remove' in label:
+            return 'remove_silence'
+        if 'seed' in label or 'seed' in parameter_name:
+            return 'seed'
+        if 'speed' in label or 'speed' in parameter_name:
+            return 'speed'
+        if 'temperature' in label or 'top_p' in label or 'cfg' in label:
+            return 'tuning'
+        return ''
+
+    def _resolve_index2_endpoint(self, client: 'Client') -> Tuple[Optional[str], Optional[int], List[Dict]]:
+        if self._index2_endpoint_cache:
+            return self._index2_endpoint_cache
+
+        try:
+            api_info = client.view_api(return_format='dict')
+        except Exception as e:
+            raise StopRetry(
+                f"获取 Index-TTS2 接口结构失败: {e}" if config.defaulelang == 'zh' else f"Failed to fetch Index-TTS2 API schema: {e}"
+            )
+
+        endpoints: List[Tuple[Optional[str], Optional[int], Dict]] = []
+        for api_name, info in api_info.get('named_endpoints', {}).items():
+            name = api_name if isinstance(api_name, str) else str(api_name)
+            if not name.startswith('/'):
+                name = '/' + name
+            endpoints.append((name, None, info))
+        for fn_index, info in api_info.get('unnamed_endpoints', {}).items():
+            try:
+                idx = int(fn_index)
+            except Exception:
+                idx = None
+            endpoints.append((None, idx, info))
+
+        errors = []
+        for api_name, fn_index, info in endpoints:
+            parameters: List[Dict] = info.get('parameters') or []
+            classified: List[Dict] = []
+            text_count = 0
+            audio_count = 0
+            missing_required: List[str] = []
+            for param in parameters:
+                kind = self._classify_index2_param(param)
+                if not kind and not param.get('parameter_has_default', False) \
+                        and not param.get('optional', False) and not param.get('parameter_optional', False):
+                    missing_required.append(param.get('label') or param.get('parameter_name') or str(param))
+                if kind == 'text':
+                    text_count += 1
+                if kind in ('audio', 'emotion'):
+                    audio_count += 1
+                param = dict(param)
+                param['__kind__'] = kind
+                classified.append(param)
+
+            if audio_count >= 1 and text_count >= 1 and not missing_required:
+                self._index2_endpoint_cache = (api_name, fn_index, classified)
+                return self._index2_endpoint_cache
+            errors.append(
+                f"api={api_name or fn_index}, missing={missing_required}, audio={audio_count}, text={text_count}"
+            )
+
+        raise StopRetry(
+            "未找到可用的 Index-TTS2 接口，请确认 webui 已启动并开放 API: " + "; ".join(errors)
+            if config.defaulelang == 'zh'
+            else "No compatible Index-TTS2 endpoint detected. Please ensure the web UI exposes an API. Details: " + "; ".join(errors)
+        )
+
+    def _build_index2_arguments(self, *,
+                                 parameters: List[Dict],
+                                 text: str,
+                                 ref_wav: str,
+                                 ref_text: str,
+                                 language_code: Optional[str],
+                                 speed: float) -> List:
+        args: List = []
+        language_code = (language_code or '').strip()
+        for param in parameters:
+            kind = param.get('__kind__') or ''
+            default = param.get('parameter_default')
+            has_default = param.get('parameter_has_default', False)
+            is_optional = param.get('optional', False) or param.get('parameter_optional', False)
+
+            try:
+                if kind == 'text':
+                    args.append(text)
+                elif kind == 'ref_text':
+                    args.append(ref_text or text)
+                elif kind in ('audio', 'emotion'):
+                    args.append(handle_file(ref_wav))
+                elif kind == 'language':
+                    args.append(language_code or default or 'en')
+                elif kind == 'remove_silence':
+                    args.append(True)
+                elif kind == 'speaker':
+                    args.append(default if default is not None else 0)
+                elif kind == 'seed':
+                    args.append(default if default is not None else 42)
+                elif kind == 'speed':
+                    args.append(speed)
+                elif kind == 'tuning':
+                    args.append(default if default is not None else 1.0)
+                else:
+                    if has_default:
+                        args.append(default)
+                    elif is_optional:
+                        args.append(None)
+                    else:
+                        raise StopRetry(
+                            f"Index-TTS2 缺少必要参数: {param.get('label') or param.get('parameter_name')}"
+                            if config.defaulelang == 'zh'
+                            else f"Index-TTS2 missing required parameter: {param.get('label') or param.get('parameter_name')}"
+                        )
+            except StopRetry:
+                raise
+            except Exception as e:
+                raise StopRetry(
+                    f"组装 Index-TTS2 参数失败: {e}" if config.defaulelang == 'zh' else f"Failed to prepare Index-TTS2 arguments: {e}"
+                )
+
+        return args
+
+    def _item_task_index2(self, data_item: Union[Dict, List, None]):
+
+        speed = 1.0
+        try:
+            speed = 1 + float(self.rate.replace('%', '')) / 100
+        except Exception:
+            pass
+
+        text = data_item['text'].strip()
+        role = data_item['role']
+        data = {'ref_wav': ''}
+
+        if role == 'clone':
+            data['ref_wav'] = data_item['ref_wav']
+        else:
+            roledict = tools.get_f5tts_role()
+            if role in roledict:
+                data['ref_wav'] = config.ROOT_DIR + f"/f5-tts/{role}"
+
+        if not Path(data['ref_wav']).exists():
+            raise StopRetry(f'{role} 角色不存在' if config.defaulelang == 'zh' else f'Role {role} does not exist')
+
+        try:
+            client = Client(self.api_url, httpx_kwargs={"timeout": 7200}, ssl_verify=False)
+        except Exception as e:
+            raise StopRetry(str(e))
+
+        api_name, fn_index, parameters = self._resolve_index2_endpoint(client)
+        args = self._build_index2_arguments(
+            parameters=parameters,
+            text=text,
+            ref_wav=data['ref_wav'],
+            ref_text=data_item.get('ref_text', ''),
+            language_code=self.language,
+            speed=speed
+        )
+
+        try:
+            result = client.predict(
+                *args,
+                api_name=api_name,
+                fn_index=fn_index
+            )
+        except TypeError as e:
+            self._index2_endpoint_cache = None
+            raise StopRetry(
+                f"Index-TTS2 调用失败: {e}. 可尝试刷新页面后重试" if config.defaulelang == 'zh'
+                else f"Index-TTS2 invocation failed: {e}. Try refreshing the schema"
+            )
+        except Exception:
+            raise
+
+        config.logger.info(f'result={result}')
+        wav_file = result[0] if isinstance(result, (list, tuple)) and result else result
+        if isinstance(wav_file, dict) and "value" in wav_file:
+            wav_file = wav_file['value']
+        if isinstance(wav_file, str) and Path(wav_file).is_file():
+            self.convert_to_wav(wav_file, data_item['filename'])
+        else:
+            raise RuntimeError(str(result))
+
+        if self.inst and self.inst.precent < 80:
+            self.inst.precent += 0.1
+
+        self.has_done += 1
+        self._signal(text=f'{config.transobj["kaishipeiyin"]} {self.has_done}/{self.len}')
+
     def _item_task_dia(self, data_item: Union[Dict, List, None]):
-        
+
         speed = 1.0
         try:
             speed = 1 + float(self.rate.replace('%', '')) / 100
@@ -274,11 +489,13 @@ class F5TTS(BaseTTS):
                 self._item_task_spark(data_item)
             elif ttstype == 'Index-TTS':
                 self._item_task_index(data_item)
+            elif ttstype == 'Index-TTS2':
+                self._item_task_index2(data_item)
             elif ttstype == 'Dia-TTS':
                 self._item_task_dia(data_item)
             else:
                 self._item_task_v1(data_item)
-            
+
 
 
 

--- a/videotrans/ui/f5tts.py
+++ b/videotrans/ui/f5tts.py
@@ -27,9 +27,9 @@ class Ui_f5ttsform(object):
         v1.addWidget(label0)
         self.ttstype = QtWidgets.QComboBox(f5ttsform)
         self.ttstype.setMinimumSize(QtCore.QSize(100, 30))
-        self.ttstype.addItems(['F5-TTS', 'Spark-TTS', 'Index-TTS', 'Dia-TTS'])
+        self.ttstype.addItems(['F5-TTS', 'Spark-TTS', 'Index-TTS', 'Index-TTS2', 'Dia-TTS'])
         self.ttstype.setToolTip(
-            '选择使用的TTS服务，支持F5-TTS/Spart-TTS/index-TTS 的官方webui服务' if config.defaulelang == 'zh' else 'Select the TTS service to use, support the official webui service of F5-TTS/Spart-TTS/index-TTS/Dia-TTS')
+            '选择使用的TTS服务，支持F5-TTS/Spark-TTS/index-TTS/index-TTS2/Dia-TTS 官方 webui 服务' if config.defaulelang == 'zh' else 'Select the TTS service to use. Official webui instances of F5-TTS/Spark-TTS/index-TTS/index-TTS2/Dia-TTS are supported')
 
         self.label = QLabel(f5ttsform)
         self.label.setObjectName("label")
@@ -105,9 +105,9 @@ class Ui_f5ttsform(object):
 
     def retranslateUi(self, f5ttsform):
         tips = """
-从本软件 v3.68 版本起，只支持使用官方的webui(F5-TTS/Spart-TTS/index-TTS/Dia-TTS)，不再支持三方整合包和api
+从本软件 v3.68 版本起，只支持使用官方的 webui(F5-TTS/Spark-TTS/index-TTS/index-TTS2/Dia-TTS)，不再支持三方整合包和 API
 """ if config.defaulelang == 'zh' else """
-Starting from version 3.68 of this software, only the official webui is supported (F5-TTS/Spart-TTS/index-TTS/Dia-TTS), and third-party integration packages and APIs are no longer supported.
+Starting from version 3.68 of this software, only the official webui endpoints are supported (F5-TTS/Spark-TTS/index-TTS/index-TTS2/Dia-TTS). Third-party integration bundles and APIs are no longer supported.
 """
 
         f5ttsform.setWindowTitle("F5-TTS/Spart-TTS/index-TTS/Dia-TTS")


### PR DESCRIPTION
## Summary
- add a Colab-focused helper (`colab_s2s.py`) and notebook that orchestrate full speech-to-speech translation with index-tts2 voice cloning
- extend the F5 TTS integration to auto-discover index-tts2 endpoints and expose the option in the UI, while updating docs/README to highlight the new workflow
- document the complete Colab setup and usage flow in `docs/google_colab_s2s.md`

## Testing
- python -m compileall colab_s2s.py videotrans/tts/_f5tts.py

------
https://chatgpt.com/codex/tasks/task_b_68d58ea6e080833192e9269d11361c18