### PR TITLE
Add Colab notebook for Index-TTS2 gradio_client workflow

### DIFF
--- a/docs/google_colab_s2s.md
+++ b/docs/google_colab_s2s.md
@@ -118,6 +118,17 @@ print(demo)
 - `/update_prompt_audio`：刷新默认参考音频；
 - `/gen_single`：执行实际合成（pyVideoTrans 默认调用此接口）。
 
+若希望在纯粹的 `gradio_client` 流程中完成识别、翻译、参考裁剪与 Index-TTS2 调用，可直接打开 `notebooks/colab_index_tts2_s2s.ipynb`。该 Notebook 会自动：
+
+1. 安装 `faster-whisper`、`librosa` 等依赖；
+2. 将视频/音频转换为标准 16 kHz 单声道 WAV；
+3. 使用 Whisper 模型识别并翻译文本；
+4. 从原声中裁剪 ≤10 秒的 timbre 参考；
+5. 解析 Index-TTS2 的 Gradio Schema 并拼装调用参数；
+6. 通过 `gradio_client` 下载合成结果并在 Colab 中回放。
+
+这份脚本化方案非常适合作为 pyVideoTrans 之外的备选实现，或在接入前验证自建 WebUI 的兼容性。
+
 ### 3. 接入自建或改造后的 TTS 服务
 
 如果你在 Index-TTS2 的基础上扩展了自定义接口，只需公开一个包含「文本输入 + 至少一个参考音频」的 Gradio Endpoint。pyVideoTrans 会自动读取 API Schema 并映射必要字段。常见场景：

--- a/notebooks/colab_index_tts2_s2s.ipynb
+++ b/notebooks/colab_index_tts2_s2s.ipynb
@@ -1,0 +1,302 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# 使用 gradio_client 的 Index-TTS2 语音互译方案",
+        "",
+        "本 Notebook 演示如何在 Google Colab 中通过 `gradio_client` 直接调用 Index-TTS2 接口，实现从视频或音频到目标语音的端到端翻译与配音流程，并自动截取不超过 10 秒的原声作为音色参考。"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 步骤概览",
+        "",
+        "1. 安装语音识别与 TTS 所需依赖。",
+        "2. 配置 Index-TTS2 服务地址以及可选参数。",
+        "3. 上传源视频或音频并提取人声轨道。",
+        "4. 通过 Faster-Whisper 自动识别原文并翻译为英文。",
+        "5. 从原音频自动裁切 ≤10 秒参考片段。",
+        "6. 读取 Index-TTS2 的 Gradio Schema，自动组装调用参数。",
+        "7. 调用接口并下载合成结果。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "!pip -q install gradio_client==0.8.1 librosa==0.10.2.post1 soundfile==0.12.1 faster-whisper==1.0.0 torch==2.4.1+cu121 torchaudio==2.4.1+cu121 --extra-index-url https://download.pytorch.org/whl/cu121\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 配置 Index-TTS2 与识别参数",
+        "",
+        "在下方单元格中填写 Index-TTS2 服务地址、API 名称，以及需要覆盖的其他参数。`CUSTOM_PAYLOAD` 可用于向接口传入额外字段（如情绪控制模式等）。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "INDEX_TTS2_ENDPOINT = \"https://<your-indextts2-host>\"\n",
+        "INDEX_TTS2_API_NAME = \"/gen_single\"\n",
+        "CUSTOM_PAYLOAD = {\n",
+        "    \"emo_control_method\": \"Same as the voice reference\"\n",
+        "}\n",
+        "WHISPER_MODEL = \"large-v3\"\n",
+        "SOURCE_LANGUAGE = \"auto\"\n",
+        "USE_TRANSLATION = True\n",
+        "USE_CUDA = True\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 上传源媒体",
+        "",
+        "支持常见的视频与音频格式，文件会被保存到会话目录中以便后续处理。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from google.colab import files\n",
+        "from pathlib import Path\n",
+        "\n",
+        "work_dir = Path(\"indextts2_work\")\n",
+        "work_dir.mkdir(exist_ok=True)\n",
+        "uploads = files.upload()\n",
+        "input_name, input_bytes = next(iter(uploads.items()))\n",
+        "input_path = work_dir / input_name\n",
+        "with open(input_path, \"wb\") as f:\n",
+        "    f.write(input_bytes)\n",
+        "print(input_path)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 提取标准化音频",
+        "",
+        "将源文件转为单声道 16 kHz WAV，以便语音识别与后续参考裁剪。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import shutil\n",
+        "import subprocess\n",
+        "\n",
+        "AUDIO_SUFFIXES = {\".wav\", \".flac\", \".mp3\", \".m4a\", \".aac\", \".ogg\", \".opus\", \".wma\", \".webm\"}\n",
+        "audio_path = work_dir / \"source.wav\"\n",
+        "if input_path.suffix.lower() in AUDIO_SUFFIXES and input_path.suffix.lower() != \".wav\":\n",
+        "    subprocess.run([\"ffmpeg\", \"-y\", \"-i\", str(input_path), \"-ac\", \"1\", \"-ar\", \"16000\", str(audio_path)], check=True)\n",
+        "elif input_path.suffix.lower() == \".wav\":\n",
+        "    shutil.copyfile(input_path, audio_path)\n",
+        "else:\n",
+        "    subprocess.run([\"ffmpeg\", \"-y\", \"-i\", str(input_path), \"-vn\", \"-ac\", \"1\", \"-ar\", \"16000\", str(audio_path)], check=True)\n",
+        "print(audio_path)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 语音识别与翻译",
+        "",
+        "使用 Faster-Whisper 获取原文，并在需要时生成英文译文作为合成文本。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import torch\n",
+        "from faster_whisper import WhisperModel\n",
+        "\n",
+        "use_cuda = USE_CUDA and torch.cuda.is_available()\n",
+        "device = \"cuda\" if use_cuda else \"cpu\"\n",
+        "compute_type = \"float16\" if use_cuda else \"int8\"\n",
+        "model = WhisperModel(WHISPER_MODEL, device=device, compute_type=compute_type)\n",
+        "language_arg = None if SOURCE_LANGUAGE.lower() == \"auto\" else SOURCE_LANGUAGE\n",
+        "segments, info = model.transcribe(str(audio_path), beam_size=5, language=language_arg, task=\"transcribe\")\n",
+        "source_text = \" \".join(segment.text.strip() for segment in segments).strip()\n",
+        "text_for_tts = source_text\n",
+        "translation_text = \"\"\n",
+        "if USE_TRANSLATION:\n",
+        "    translated_segments, _ = model.transcribe(str(audio_path), beam_size=5, language=language_arg, task=\"translate\")\n",
+        "    translation_text = \" \".join(segment.text.strip() for segment in translated_segments).strip()\n",
+        "    if translation_text:\n",
+        "        text_for_tts = translation_text\n",
+        "print(\"原文:\", source_text)\n",
+        "print(\"合成文本:\", text_for_tts)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 裁剪音色参考",
+        "",
+        "自动截取前 10 秒内的单声道片段，并保存为 Index-TTS2 可直接上传的 WAV 文件。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import librosa\n",
+        "import soundfile as sf\n",
+        "\n",
+        "ref_audio, ref_sr = librosa.load(str(audio_path), sr=None, mono=True)\n",
+        "max_samples = min(len(ref_audio), int(ref_sr * 10))\n",
+        "if max_samples == 0:\n",
+        "    raise RuntimeError(\"参考音频过短，无法裁剪\")\n",
+        "ref_clip = ref_audio[:max_samples]\n",
+        "ref_path = work_dir / \"reference.wav\"\n",
+        "sf.write(ref_path, ref_clip, ref_sr)\n",
+        "print(ref_path, max_samples / ref_sr)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 读取 Index-TTS2 接口结构",
+        "",
+        "自动解析目标 Endpoint 的参数顺序，确保传入文本与参考音频字段齐全。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from gradio_client import Client, handle_file\n",
+        "\n",
+        "client = Client(INDEX_TTS2_ENDPOINT)\n",
+        "api_schema = client.view_api(return_format=\"dict\")\n",
+        "endpoint_schema = api_schema.get(\"named_endpoints\", {}).get(INDEX_TTS2_API_NAME)\n",
+        "if endpoint_schema is None:\n",
+        "    named_values = list(api_schema.get(\"named_endpoints\", {}).values())\n",
+        "    if named_values:\n",
+        "        endpoint_schema = named_values[0]\n",
+        "if endpoint_schema is None:\n",
+        "    unnamed_values = list(api_schema.get(\"unnamed_endpoints\", {}).values())\n",
+        "    if unnamed_values:\n",
+        "        endpoint_schema = unnamed_values[0]\n",
+        "if endpoint_schema is None:\n",
+        "    raise RuntimeError(\"无法解析 Index-TTS2 接口结构\")\n",
+        "parameters = endpoint_schema.get(\"parameters\", [])\n",
+        "print(len(parameters))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 调用 Index-TTS2 并获取结果",
+        "",
+        "根据 Schema 自动组装请求参数，调用后将结果下载到本地目录并直接在 Colab 中试听。"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from gradio_client import utils as gr_utils\n",
+        "from IPython.display import Audio, display\n",
+        "\n",
+        "output_dir = work_dir / \"tts_output\"\n",
+        "output_dir.mkdir(exist_ok=True)\n",
+        "\n",
+        "def assemble_inputs(param_list, text_value, reference_file, overrides):\n",
+        "    values = []\n",
+        "    for param in param_list:\n",
+        "        name = param.get(\"parameter_name\") or param.get(\"label\")\n",
+        "        component = param.get(\"component\")\n",
+        "        if name in overrides:\n",
+        "            values.append(overrides[name])\n",
+        "        elif component in {\"Textbox\", \"TextArea\"}:\n",
+        "            values.append(text_value)\n",
+        "        elif component in {\"Audio\", \"File\", \"UploadButton\"}:\n",
+        "            values.append(handle_file(reference_file))\n",
+        "        elif param.get(\"parameter_has_default\", False):\n",
+        "            values.append(param.get(\"parameter_default\"))\n",
+        "        else:\n",
+        "            raise RuntimeError(f\"缺少必要字段: {name}\")\n",
+        "    return values\n",
+        "\n",
+        "def harvest_files(data, target_dir):\n",
+        "    collected = []\n",
+        "    def visit(node):\n",
+        "        if isinstance(node, dict):\n",
+        "            url = None\n",
+        "            for key in (\"url\", \"path\"):\n",
+        "                value = node.get(key)\n",
+        "                if isinstance(value, str) and value.startswith(\"http\"):\n",
+        "                    url = value\n",
+        "                    break\n",
+        "            if url:\n",
+        "                saved = gr_utils.download_tmp_copy_of_file(url, dir=str(target_dir))\n",
+        "                collected.append(saved)\n",
+        "            for value in node.values():\n",
+        "                visit(value)\n",
+        "        elif isinstance(node, (list, tuple, set)):\n",
+        "            for value in node:\n",
+        "                visit(value)\n",
+        "        elif isinstance(node, str) and node.startswith(\"http\"):\n",
+        "            saved = gr_utils.download_tmp_copy_of_file(node, dir=str(target_dir))\n",
+        "            collected.append(saved)\n",
+        "    visit(data)\n",
+        "    return collected\n",
+        "\n",
+        "request_values = assemble_inputs(parameters, text_for_tts, ref_path, CUSTOM_PAYLOAD)\n",
+        "raw_response = client.predict(*request_values, api_name=INDEX_TTS2_API_NAME)\n",
+        "print(raw_response)\n",
+        "output_files = harvest_files(raw_response, output_dir)\n",
+        "print(output_files)\n",
+        "for item in output_files:\n",
+        "    display(Audio(item))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Chinese-language Colab notebook that walks through an end-to-end Index-TTS2 speech-to-speech pipeline using gradio_client, including media upload, Whisper transcription, ≤10s timbre clipping, and dynamic payload assembly
- document the notebook in the Index-TTS2 Colab guide so users can adopt the standalone gradio_client workflow as an optional alternative

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d66e12a4688331ae2ef06d13cd5b92